### PR TITLE
Feat/todo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ WebStart-Backend-Java/
 │         └─── java/                                                      # Einstiegspunkt für Java-Pakete (Source Root)
 │              └─── com/semsoko/webstartbackend/                          # Root-Package für das Backend
 │                        └─── todo/                                       # Modul für Todo-Funktionalität
-│                             ├─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
-│                             │    └─── Todo.java                         # Datenobjekt mit id, title, done
-│                             └─── dto/                                   # Datenübertragungsobjekte (Request/Response)
-│                                  └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
+│                             ├─── controller/                            # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/todos)
+│                             │    └─── TodoController.java               # Steuerung eingehender HTTP-Anfragen
+│                             ├─── dto/                                   # Datenübertragungsobjekte (Request/Response)
+│                             │    └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
+│                             └─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
+│                                  └─── Todo.java                         # Datenobjekt mit id, title, done
 │
 └─── README.md                                                            # Projektbeschreibung & Strukturübersicht
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 ```
 WebStart-Backend-Java/
 ├── src/
-│    └─── main/                                             # Haupt-Quellcode (Java, Ressourcen, etc.)
-│         └─── java/                                        # Einstiegspunkt für Java-Pakete (Source Root)
-│              └─── com/semsoko/webstartbackend/            # Root-Package für das Backend
-│                        └─── todo/                         # Modul für Todo-Funktionalität
-│                             └─── model/                   # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
+│    └─── main/                                                           # Haupt-Quellcode (Java, Ressourcen, etc.)
+│         └─── java/                                                      # Einstiegspunkt für Java-Pakete (Source Root)
+│              └─── com/semsoko/webstartbackend/                          # Root-Package für das Backend
+│                        └─── todo/                                       # Modul für Todo-Funktionalität
+│                             ├─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
+│                             │    └─── Todo.java                         # Datenobjekt mit id, title, done
+│                             └─── dto/                                   # Datenübertragungsobjekte (Request/Response)
+│                                  └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
 │
-└─── README.md
+└─── README.md                                                            # Projektbeschreibung & Strukturübersicht
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+```
+WebStart-Backend-Java/
+├── src/
+│    └─── main/                                             # Haupt-Quellcode (Java, Ressourcen, etc.)
+│         └─── java/                                        # Einstiegspunkt für Java-Pakete (Source Root)
+│              └─── com/semsoko/webstartbackend/            # Root-Package für das Backend
+│                        └─── todo/                         # Modul für Todo-Funktionalität
+│                             └─── model/                   # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
+│
+└─── README.md
+```

--- a/src/main/java/com/semsoko/webstartbackend/todo/controller/TodoController.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/controller/TodoController.java
@@ -1,0 +1,37 @@
+package com.semsoko.webstartbackend.todo.controller;
+
+import com.semsoko.webstartbackend.todo.dto.NewTodoRequest;
+import com.semsoko.webstartbackend.todo.model.Todo;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * RestController -> macht aus der Klasse einen HTTP-Controller
+ * RequestMapping("/api/todos") -> Basisroute
+ */
+@RestController
+@RequestMapping("api/todos")
+public class TodoController {
+    private final List<Todo> todos = new ArrayList<>();
+
+    /**
+     * PostMapping -> Methode für POST-Anfragen
+     */
+    @PostMapping
+    public Todo createTodo(
+            /**
+             * RequestBody -> Spring mappt das JSON in NewTodoRequest
+             */
+            @RequestBody NewTodoRequest request
+    ){
+        Todo newTodo = new Todo(request.getTitle());
+        /**
+         * Liste speichert Todos im Arbeitsspeicher (noch keine DB)
+         */
+        todos.add(newTodo);
+
+        return newTodo;
+    }
+}

--- a/src/main/java/com/semsoko/webstartbackend/todo/dto/NewTodoRequest.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/dto/NewTodoRequest.java
@@ -1,4 +1,19 @@
 package com.semsoko.webstartbackend.todo.dto;
 
+/**
+ * NewTodoRequest ist ein DTO für die Eingabe per JSON.
+ * Es kapselt nur die Felder, die der Client beim Erstellen eines Todos mitschickt.
+ * So trennen wir externe Eingabe von interner Logik (z.B. automatische ID-Vergabe).
+ */
+
 public class NewTodoRequest {
+    private String title;
+
+    public String getTitle(){
+        return title;
+    }
+
+    public void setTitle(String title){
+        this.title = title;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/todo/dto/NewTodoRequest.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/dto/NewTodoRequest.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.todo.dto;
+
+public class NewTodoRequest {
+}

--- a/src/main/java/com/semsoko/webstartbackend/todo/model/Todo.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/model/Todo.java
@@ -1,4 +1,34 @@
 package com.semsoko.webstartbackend.todo.model;
 
 public class Todo {
+    /**
+     * static idCounter simuliert aktuell eine fortlaufende ID – in echten
+     * Anwendungen übernimmt das später die Datenbank.
+     */
+    private static int idCounter = 1;
+    private Integer id;
+    private String title;
+    private Boolean done;
+
+    public Todo(String title){
+        this.id = idCounter++;
+        this.title = title;
+        this.done = false;
+    }
+
+    public Integer getId(){
+        return this.id;
+    }
+
+    public String getTitle(){
+        return this.title;
+    }
+
+    public Boolean getDone(){
+        return this.done;
+    }
+
+    public void setDone(Boolean status){
+        this.done = status;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/todo/model/Todo.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/model/Todo.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.todo.model;
+
+public class Todo {
+}


### PR DESCRIPTION
### Hintergrund

Erster technischer Startpunkt für das neue Todo-Modul.
Ziel ist es, die bestehenden PHP-Endpunkte schrittweise nach Spring Boot zu migrieren.
In diesem Branch wurde die Grundlage geschaffen, um Todos im Java-Backend zu verarbeiten.

---

### Änderungen im Detail

- Neues Datenmodell Todo.java mit id, title und done-Status
- DTO NewTodoRequest.java zur Verarbeitung eingehender JSON-Daten
- REST-Controller TodoController.java mit einem ersten POST-Endpunkt
- Temporärer in-memory Speicher (List<Todo>) zur Verwaltung der Todos ohne Datenbank

---

### Ziel / Zweck des PRs

Bereitstellung eines funktionsfähigen Einstiegspunkts für das neue Todo-Modul,
das später um Service-Logik, Repository und Datenbankanbindung erweitert wird.

---

### Testhinweise

- Server starten (./gradlew bootRun)

- Per Insomnia/Postman anfragen:
  - `POST http://localhost:8080/api/todos` mit Payload: `{ "title": "Einkaufen" }`
- Erwartete Rückgabe: Todo-Objekt mit ID, Titel und done = false
- Ausgabe im Terminal zeigt aktuelle Liste der Todos
---

### Hinweise für Reviewer

- Liste wird aktuell nur im RAM gespeichert, nicht persistiert
- Noch keine Validierung der Eingabedaten
- Kein GET-Endpunkt oder Error-Handling enthalten