### PR TITLE
Feat/add todo repository layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ WebStart-Backend-Java/
 │                             │    └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
 │                             ├─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
 │                             │    └─── Todo.java                         # Datenobjekt mit id, title, done
+│                             ├─── repository/                            # Schnittstelle und Implementierung zur Speicherung von Todos
+│                             │    ├─── InMemoryTodoRepository.java       # In-Memory-Implementierung der Speicherung für das dev-Profil
+│                             │    └─── TodoRepository.java               # Repository-Interface für die Datenzugriffsschicht
 │                             └─── service/                               # Geschäftslogik für Todos (z. B. erstellen, speichern)
 │                                  ├─── InMemoryTodoService.java          # Zentrale Logik zum Anlegen und Verwalten von Todos
 │                                  └─── TodoService.java                  # Interface zur Definition der Todo-Service-Verträge

--- a/src/main/java/com/semsoko/webstartbackend/todo/repository/InMemoryTodoRepository.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/repository/InMemoryTodoRepository.java
@@ -1,0 +1,26 @@
+package com.semsoko.webstartbackend.todo.repository;
+
+import com.semsoko.webstartbackend.todo.model.Todo;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Profile("dev")
+@Repository
+@Qualifier("inMemory")
+public class InMemoryTodoRepository implements TodoRepository{
+    private final List<Todo> todos = new ArrayList<>();
+
+    @Override
+    public void save(Todo todo){
+        todos.add(todo);
+    }
+
+    @Override
+    public List<Todo> findAll(){
+        return todos;
+    }
+}

--- a/src/main/java/com/semsoko/webstartbackend/todo/repository/TodoRepository.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/repository/TodoRepository.java
@@ -1,0 +1,10 @@
+package com.semsoko.webstartbackend.todo.repository;
+
+import com.semsoko.webstartbackend.todo.model.Todo;
+
+import java.util.List;
+
+public interface TodoRepository {
+    void save(Todo todo);
+    List<Todo> findAll();
+}

--- a/src/main/java/com/semsoko/webstartbackend/todo/service/InMemoryTodoService.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/service/InMemoryTodoService.java
@@ -2,27 +2,26 @@ package com.semsoko.webstartbackend.todo.service;
 
 import com.semsoko.webstartbackend.todo.dto.NewTodoRequest;
 import com.semsoko.webstartbackend.todo.model.Todo;
+import com.semsoko.webstartbackend.todo.repository.TodoRepository;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Profile("dev")
 @Service
 @Qualifier("inMemory")
 public class InMemoryTodoService implements TodoService{
-    /**
-     * Temporaerer In-Memory-Speicher, wird spaeter ins Repository ausgelagert.
-     */
-    private final List<Todo> todos = new ArrayList<>();
+    private final TodoRepository repository;
+
+    public InMemoryTodoService(@Qualifier("inMemory") TodoRepository repository){
+        this.repository = repository;
+    }
 
     @Override
     public Todo createTodo(NewTodoRequest request){
         Todo newTodo = new Todo(request.getTitle());
-        todos.add(newTodo);
-
+        repository.save(newTodo);
         return newTodo;
     }
 }


### PR DESCRIPTION
### Hintergrund

Im Rahmen der Weiterentwicklung der Todo-Funktionalität wurde entschieden, die Datenhaltung von der Service-Schicht zu trennen.
Ziel war es, eine klare Repository-Schicht einzuführen, um den Code besser strukturieren, austauschbarer machen und sauberere Dependency Injection zu ermöglichen.

---

### Änderungen im Detail

- Einführung des TodoRepository-Interfaces zur Definition der Zugriffsmethoden
- Implementierung des InMemoryTodoRepository für das dev-Profil
- Anpassung von InMemoryTodoService, sodass die Speicherung über das Repository erfolgt
- Nutzung von @Qualifier und @Profile für präzise Steuerung der aktiven Komponenten
- Entfernen der direkten Speicherung im Service (List<Todo> entfernt)

---

### Ziel / Zweck des PRs

- Trennung von Geschäftslogik (Service) und Datenhaltung (Repository)
- Ermöglichung zukünftiger Repository-Implementierungen (z. B. Datenbank)
- Förderung von Testbarkeit und Austauschbarkeit durch saubere Abstraktion
- Einhaltung von Spring Best Practices im Hinblick auf DI

---

### Testhinweise

- Test über POST-Anfragen an /api/todos im aktiven dev-Profil
- Überprüfung, ob Todos erfolgreich gespeichert werden (In-Memory)

---

### Hinweise für Reviewer

- InMemoryTodoRepository ist bewusst einfach gehalten, da die Persistenz später ausgetauscht wird
- Die Trennung in Interface + Implementierung folgt dem Pattern aus dem Service-Layer
- Qualifier sind bereits gesetzt, auch wenn nur eine Implementierung vorhanden ist → für spätere Erweiterung