### PR TITLE
Feat/add postgres jpa repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,41 @@
 ```
 WebStart-Backend-Java/
 ├── src/
-│    └─── main/                                                           # Haupt-Quellcode (Java, Ressourcen, etc.)
-│         ├─── java/                                                      # Einstiegspunkt für Java-Pakete (Source Root)
-│         │    └─── com/semsoko/webstartbackend/                          # Root-Package für das Backend
-│         │               └─── todo/                                       # Modul für Todo-Funktionalität
-│         │                    ├─── controller/                            # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/todos)
-│         │                    │    └─── TodoController.java               # Steuerung eingehender HTTP-Anfragen
-│         │                    ├─── dto/                                   # Datenübertragungsobjekte (Request/Response)
-│         │                    │    └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
-│         │                    ├─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
-│         │                    │    └─── Todo.java                         # Datenobjekt mit id, title, done
-│         │                    ├─── repository/                            # Schnittstelle und Implementierung zur Speicherung von Todos
-│         │                    │    ├─── InMemoryTodoRepository.java       # In-Memory-Implementierung der Speicherung für das dev-Profil
-│         │                    │    └─── TodoRepository.java               # Repository-Interface für die Datenzugriffsschicht
-│         │                    └─── service/                               # Geschäftslogik für Todos (z. B. erstellen, speichern)
-│         │                         ├─── InMemoryTodoService.java          # Zentrale Logik zum Anlegen und Verwalten von Todos
-│         │                         └─── TodoService.java                  # Interface zur Definition der Todo-Service-Verträge
+│    └─── main/                                                       # Haupt-Quellcode (Java, Ressourcen, etc.)
+│         ├─── java/                                                  # Einstiegspunkt für Java-Pakete (Source Root)
+│         │    ├─── com.semsoko.webstartbackend/                      # Root-Package für das Backend
+│         │    │    ├─── todo/                                        # Modul für Todo-Funktionalität
+│         │    │    │    ├─── controller/                             # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/todos)
+│         │    │    │    │    └─── TodoController.java                # Steuerung eingehender HTTP-Anfragen
+│         │    │    │    ├─── dto/                                    # Datenübertragungsobjekte (Request/Response)
+│         │    │    │    │    └─── NewTodoRequest.java                # Eingabeobjekt für neue Todos (z. B. via JSON)
+│         │    │    │    ├─── model/                                  # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
+│         │    │    │    │    ├─── Todo.java                          # Datenobjekt mit id, title, done
+│         │    │    │    │    └─── TodoEntity.java                    # JPA-Entity zur Abbildung von Todos in der Datenbank
+│         │    │    │    ├─── repository/                             # Schnittstelle und Implementierung zur Speicherung von Todos
+│         │    │    │    │    ├─── InMemoryTodoRepository.java        # In-Memory-Implementierung der Speicherung für das dev-Profil
+│         │    │    │    │    └─── TodoRepository.java                # Repository-Interface für die Datenzugriffsschicht
+│         │    │    │    └─── service/                                # Geschäftslogik für Todos (z. B. erstellen, speichern)
+│         │    │    │               ├─── InMemoryTodoService.java     # Zentrale Logik zum Anlegen und Verwalten von Todos
+│         │    │    │               └─── TodoService.java             # Interface zur Definition der Todo-Service-Verträge
+│         │    │    │
+│         │    │    └─── Application.java                             # Einstiegspunkt der Spring Boot Anwendung (main-Methode + Spring-Kontext)
+│         │    │
+│         │    └─── resources/                                        # Konfiguration der Spring-Anwendung
+│         │         ├─── application.properties                       # Globale Konfiguration – aktiviert das gewünschte Profil (z. B. dev)
+│         │         └─── application-dev.properties                   # Profilabhängige Konfiguration – PostgreSQL-Einstellungen für die lokale Entwicklung
 │         │
-│         └─── resources/                                                  # Konfiguration der Spring-Anwendung
-│              ├─── application.properties                                 # Globale Konfiguration – aktiviert das gewünschte Profil (z. B. dev)
-│              └─── application-dev.properties                             # Profilabhängige Konfiguration – PostgreSQL-Einstellungen für die lokale Entwicklung
+│         └─── test/                                                  # Testverzeichnis mit isolierten Tests, Profilen und Konfigurationen
+│              ├─── java/                                             # Test-Quellcode
+│              │    └─── com.semsoko.webstartbackend/                 # Package-Struktur analog zur Hauptanwendung für Testklassen
+│              │         └─── ApplicationTest.java                    # Basis-Test zum Starten des Spring-Kontexts
+│              │
+│              └─── resources/                                        # Ressourcen für Tests (z. B. Testdatenbanken, Profilkonfiguration)
+│                   └─── application-test.properties                  # Konfiguration für das "test"-Profil mit H2-In-Memory-Datenbank
 │
-└─── README.md                                                             # Projektbeschreibung & Strukturübersicht
+│
+├─── build.gradle                                                     # Gradle-Buildskript mit Abhängigkeiten und Konfigurationen
+└─── README.md                                                        # Projektbeschreibung & Strukturübersicht
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -40,13 +40,63 @@ WebStart-Backend-Java/
 
 ---
 
+### Datenbank
+
+Dieses Projekt verwendet PostgreSQL als relationale Datenbank. Die Datenbank
+wird lokal über Docker bereitgestellt, was eine einfache und reproduzierbare
+Entwicklungsumgebung ermöglicht.
+
+Für Testzwecke wird eine H2 In-Memory-Datenbank verwendet, um schnelle und
+isolierte Tests ohne externe Abhängigkeiten zu ermöglichen.
+
+### Datenbankkonfiguration
+
+## Entwicklungsumgebung (Profil: dev)
+
+Die Verbindung zur PostgreSQL-Datenbank erfolgt über das Spring-Profil `dev`.\
+- Konfiguration: `src/main/resources/application-dev.properties`
+- Aktivierung des Profils:\
+  - In `application.properties`, per:\
+    `spring.profiles.active=dev`\
+  - Ueber `@Profile("dev")` in:
+    - `InMemoryTodoRepository.java`
+	- `InMemoryTodoService.java`
+
+# Hinweise
+
+Zugangsdaten sind aktuell in application-dev.properties hinterlegt.\
+Eine .env-Datei zur sicheren Verwaltung sensibler Daten (z. B. DB_PASSWORD) ist in Planung.\
+
+In der Datei: `/var/lib/postgresql/data/pg_hba.conf` der PostgreSQL-Instanz wurde die\
+Authentifizierungsmethode auf `md5` gesetzt.
+
+## Testumgebung (Profil: test)
+
+Für automatisierte Tests wird eine In-Memory-H2-Datenbank genutzt.\
+- Konfiguration: `src/test/resources/application-test.properties`
+- Aktivierung des Profils:
+  - Über Annotation `@ActiveProfiles("test")` in:
+  - `ApplicationTest.java`
+
 ### Anwendungskonfiguration
 
 Die Anwendung verwendet Spring Profile-Management zur Auswahl der Umgebung.\
-Aktives Profil (in `application.properties`):
+Das aktive Profil wird in `application.properties` gesetzt:
 
 ```properties\
 spring.profiles.active=dev\
 ```
 
--> Steuert, welche Service-Implementierung aktiv ist (z. B. InMemoryTodoService bei "dev")
+-> Steuert, welche Konfiguration und Service-Implementierung aktiv sind
+
+### Infrastruktur & CI/CD (in Planung)
+
+Zur besseren Trennung von Code und Infrastruktur ist ein separates Repository\
+geplant, in dem alle relevanten Themen rund um:
+
+- CI/CD (z. B. GitHub Actions, Tests, Deployments)
+- Docker & Containerisierung
+- Konfigurationsmanagement
+- Sicherheitsaspekte (Secrets, .env, Vault, etc.)
+
+dokumentiert und gepflegt werden.

--- a/README.md
+++ b/README.md
@@ -2,23 +2,27 @@
 WebStart-Backend-Java/
 ├── src/
 │    └─── main/                                                           # Haupt-Quellcode (Java, Ressourcen, etc.)
-│         └─── java/                                                      # Einstiegspunkt für Java-Pakete (Source Root)
-│              └─── com/semsoko/webstartbackend/                          # Root-Package für das Backend
-│                        └─── todo/                                       # Modul für Todo-Funktionalität
-│                             ├─── controller/                            # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/todos)
-│                             │    └─── TodoController.java               # Steuerung eingehender HTTP-Anfragen
-│                             ├─── dto/                                   # Datenübertragungsobjekte (Request/Response)
-│                             │    └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
-│                             ├─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
-│                             │    └─── Todo.java                         # Datenobjekt mit id, title, done
-│                             ├─── repository/                            # Schnittstelle und Implementierung zur Speicherung von Todos
-│                             │    ├─── InMemoryTodoRepository.java       # In-Memory-Implementierung der Speicherung für das dev-Profil
-│                             │    └─── TodoRepository.java               # Repository-Interface für die Datenzugriffsschicht
-│                             └─── service/                               # Geschäftslogik für Todos (z. B. erstellen, speichern)
-│                                  ├─── InMemoryTodoService.java          # Zentrale Logik zum Anlegen und Verwalten von Todos
-│                                  └─── TodoService.java                  # Interface zur Definition der Todo-Service-Verträge
+│         ├─── java/                                                      # Einstiegspunkt für Java-Pakete (Source Root)
+│         │    └─── com/semsoko/webstartbackend/                          # Root-Package für das Backend
+│         │               └─── todo/                                       # Modul für Todo-Funktionalität
+│         │                    ├─── controller/                            # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/todos)
+│         │                    │    └─── TodoController.java               # Steuerung eingehender HTTP-Anfragen
+│         │                    ├─── dto/                                   # Datenübertragungsobjekte (Request/Response)
+│         │                    │    └─── NewTodoRequest.java               # Eingabeobjekt für neue Todos (z. B. via JSON)
+│         │                    ├─── model/                                 # Enthält interne Datenmodelle, die zentrale Strukturen im Code darstellen
+│         │                    │    └─── Todo.java                         # Datenobjekt mit id, title, done
+│         │                    ├─── repository/                            # Schnittstelle und Implementierung zur Speicherung von Todos
+│         │                    │    ├─── InMemoryTodoRepository.java       # In-Memory-Implementierung der Speicherung für das dev-Profil
+│         │                    │    └─── TodoRepository.java               # Repository-Interface für die Datenzugriffsschicht
+│         │                    └─── service/                               # Geschäftslogik für Todos (z. B. erstellen, speichern)
+│         │                         ├─── InMemoryTodoService.java          # Zentrale Logik zum Anlegen und Verwalten von Todos
+│         │                         └─── TodoService.java                  # Interface zur Definition der Todo-Service-Verträge
+│         │
+│         └─── resources/                                                  # Konfiguration der Spring-Anwendung
+│              ├─── application.properties                                 # Globale Konfiguration – aktiviert das gewünschte Profil (z. B. dev)
+│              └─── application-dev.properties                             # Profilabhängige Konfiguration – PostgreSQL-Einstellungen für die lokale Entwicklung
 │
-└─── README.md                                                            # Projektbeschreibung & Strukturübersicht
+└─── README.md                                                             # Projektbeschreibung & Strukturübersicht
 ```
 
 ---

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.postgresql:postgresql'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/semsoko/webstartbackend/todo/model/TodoEntity.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/model/TodoEntity.java
@@ -1,0 +1,43 @@
+package com.semsoko.webstartbackend.todo.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "todos")
+public class TodoEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private Boolean done = false;
+
+    public TodoEntity(){
+
+    }
+
+    public TodoEntity(String title){
+        this.title = title;
+    }
+
+    /**
+     * Getter
+     */
+    public Long getId(){
+        return this.id;
+    }
+
+    public String getTitle(){
+        return this.title;
+    }
+
+    public Boolean getDone(){
+        return this.done;
+    }
+
+    /**
+     * Setter
+     */
+    public void setDone(Boolean done){
+        this.done = done;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,9 +1,0 @@
-# PostgreSQL (lokal oder via Docker)
-spring.datasource.url=jdbc:postgresql://localhost:5432/webstart
-spring.datasource.username=admin
-spring.datasource.password=123
-
-# JPA & Hibernate
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:postgresql://localhost:6543/test_db
 spring.datasource.username=semion
-spring.datasource.password=1234567
+spring.datasource.password=123
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,9 @@
+# PostgreSQL (lokal oder via Docker)
+spring.datasource.url=jdbc:postgresql://localhost:5432/webstart
+spring.datasource.username=admin
+spring.datasource.password=123
+
+# JPA & Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:postgresql://localhost:6543/test_db
+spring.datasource.username=semion
+spring.datasource.password=1234567
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-spring.application.name=com.semsoko.webstartbackend
+spring.application.name=webstart
 spring.profiles.active=dev

--- a/src/test/java/com/semsoko/webstartbackend/ApplicationTests.java
+++ b/src/test/java/com/semsoko/webstartbackend/ApplicationTests.java
@@ -2,8 +2,10 @@ package com.semsoko.webstartbackend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
### Hintergrund

Dieser PR integriert die PostgreSQL-Datenbank über JPA in das bestehende Spring Boot Backend.
Ziel ist es, produktive Datenbankanbindung im dev-Profil zu ermöglichen sowie eine klare Trennung zwischen Produktiv- und Testkonfigurationen zu schaffen.

---

### Änderungen im Detail

- Einführung der TodoEntity als JPA-Entity
- Ergänzung von application-dev.properties mit PostgreSQL-Konfiguration
- Ergänzung von application-test.properties mit H2-In-Memory-Testdatenbank
- Anpassung von build.gradle (Dependencies für JPA, PostgreSQL, H2)
- Aktivierung von Profilen per application.properties und @ActiveProfiles
- Erweiterung der README.md um:
  - Projektstruktur
  - DB-Konfiguration (dev + test)
  - Hinweis zu pg_hba.conf (md5)
  - Ausblick auf .env und geplantes CI/CD-Repo

---

### Ziel / Zweck des PRs

- Nutzung von PostgreSQL in der lokalen Entwicklungsumgebung (via Docker)
- Nutzung von H2 für isolierte Tests
- Saubere Trennung von Konfigurationen per Spring Profiles
- Verbesserte Nachvollziehbarkeit durch aktualisierte README.md

---

### Testhinweise

- Anwendung starten mit Profil dev → Verbindung zur PostgreSQL-Datenbank prüfen
- Testlauf (./gradlew test) → Ausführung über H2-In-Memory-DB mit Profil test
- TodoEntity wird korrekt über JPA persistiert

---

### Hinweise für Reviewer

- Die Passwortverwaltung ist aktuell noch direkt in Properties hinterlegt – .env-Support folgt.
- pg_hba.conf muss lokal auf md5 eingestellt sein.

---

### Folgeänderungen (optional)

- Einführung einer .env-Datei