### PR TITLE
Feat/get all todos endpoint

### DIFF
--- a/src/main/java/com/semsoko/webstartbackend/todo/service/InMemoryTodoService.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/service/InMemoryTodoService.java
@@ -55,6 +55,15 @@ public class InMemoryTodoService implements TodoService{
         return mapper.mapToResponse(newTodo);
     }
 
+    /**
+     * Ruft alle gespeicherten Todos aus dem In-Memory-Repository ab und
+     * wandlet sie in {@link TodoResponse}-Objekte um.
+     *
+     * Diese Methode ist nur im Profil "dev-inmemory" aktiv und dient der lokalen Entwicklung
+     * ohne persistente Datenbank.
+     *
+     * @return Liste aller Todos als API-geeignete {@link TodoResponse}-Objekte
+     */
     @Override
     public List<TodoResponse> findAll(){
         return repository.findAll()

--- a/src/main/java/com/semsoko/webstartbackend/todo/service/InMemoryTodoService.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/service/InMemoryTodoService.java
@@ -6,6 +6,8 @@ import com.semsoko.webstartbackend.todo.repository.TodoRepository;
 import com.semsoko.webstartbackend.todo.dto.TodoResponse;
 import com.semsoko.webstartbackend.todo.mapper.TodoMapper;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -51,5 +53,13 @@ public class InMemoryTodoService implements TodoService{
         Todo newTodo = new Todo(request.getTitle());
         repository.save(newTodo);
         return mapper.mapToResponse(newTodo);
+    }
+
+    @Override
+    public List<TodoResponse> findAll(){
+        return repository.findAll()
+                .stream()
+                .map(mapper::mapToResponse)
+                .toList();
     }
 }

--- a/src/main/java/com/semsoko/webstartbackend/todo/service/PostgresTodoService.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/service/PostgresTodoService.java
@@ -7,6 +7,8 @@ import com.semsoko.webstartbackend.todo.repository.JpaTodoRepository;
 import com.semsoko.webstartbackend.todo.mapper.TodoMapper;
 import com.semsoko.webstartbackend.todo.dto.TodoResponse;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -46,5 +48,19 @@ public class PostgresTodoService implements TodoService{
         TodoEntity saved = repository.save(entity);
 
         return mapper.mapToResponse(saved);
+    }
+
+    /**
+     * Ruft alle Todos aus der PostgreSQL-Datenbank ab
+     * und wandelt sie in {@link TodoResponse}-Objekte um.
+     *
+     * @return Liste aller Todos in API-kompatibler Struktur.
+     */
+    @Override
+    public List<TodoResponse> findAll(){
+        return repository.findAll()
+                .stream()
+                .map(mapper::mapToResponse)
+                .toList();
     }
 }

--- a/src/main/java/com/semsoko/webstartbackend/todo/service/TodoService.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/service/TodoService.java
@@ -3,6 +3,9 @@ package com.semsoko.webstartbackend.todo.service;
 import com.semsoko.webstartbackend.todo.dto.NewTodoRequest;
 import com.semsoko.webstartbackend.todo.dto.TodoResponse;
 
+import java.util.List;
+
 public interface TodoService {
     TodoResponse createTodo(NewTodoRequest request);
+    List<TodoResponse> findAll();
 }


### PR DESCRIPTION
### Hintergrund

Im bestehenden Todo-Modul war bisher nur das Erstellen eines Todos (POST /api/todos) möglich. Um eine vollständige API-Grundfunktionalität sicherzustellen, wurde nun die Möglichkeit ergänzt, alle vorhandenen Todos abrufen zu können.

---

### Änderungen im Detail

- Erweiterung des TodoService-Interfaces um die Methode findAll()
- Implementierung von findAll() in beiden Service-Implementierungen:
  - InMemoryTodoService
  - PostgresTodoService
- Verwendung des TodoMapper, um interne Modelle (Todo, TodoEntity) in TodoResponse-DTOs zu konvertieren
- Ergänzung des TodoController um den GET-Endpunkt /api/todos
- JavaDoc für Service-Methoden ergänzt

---

### Ziel / Zweck des PRs

Bereitstellung eines API-Endpunkts zur Abfrage aller Todos als Teil der Basisfunktionalität. Dies ermöglicht sowohl UI-Anbindungen als auch automatisierte Tests oder zukünftige Erweiterungen (z. B. Filterung, Pagination).

---

### Testhinweise

- Starte die Anwendung mit dem gewünschten Profil (dev-inmemory oder dev-postgres)
- Rufe folgenden Endpunkt im Browser oder mit einem Tool wie Insomnia/Postman auf:
  - `GET http://localhost:8080/api/todos`

- Erwartetes Ergebnis:
  - Status: 200 OK
  - Body: Liste von Todos (leere Liste, wenn keine vorhanden sind)

---

### Hinweise für Reviewer

- Mapper ist bereits im Einsatz, sodass der Controller von internen Modellen entkoppelt ist
- Die neue Logik greift auf bestehende Repository-Implementierungen zurück – keine Änderungen an Repositorys notwendig