### PR TITLE
Feat/booking module jpa scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,26 @@ WebStart-Backend-Java/
 │         │    │    │    │    ├─── InMemoryTodoRepository.java        # In-Memory-Implementierung der Speicherung für das dev-Profil
 │         │    │    │    │    └─── TodoRepository.java                # Repository-Interface für die Datenzugriffsschicht
 │         │    │    │    └─── service/                                # Geschäftslogik für Todos (z. B. erstellen, speichern)
-│         │    │    │               ├─── InMemoryTodoService.java     # Zentrale Logik zum Anlegen und Verwalten von Todos
-│         │    │    │               └─── TodoService.java             # Interface zur Definition der Todo-Service-Verträge
+│         │    │    │         ├─── InMemoryTodoService.java           # Zentrale Logik zum Anlegen und Verwalten von Todos
+│         │    │    │         └─── TodoService.java                   # Interface zur Definition der Todo-Service-Verträge
+│         │    │    │
+│         │    │    ├─── booking/                                     # Modul für Buchungsfunktionalität
+│         │    │    │    ├─── controller/                             # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/bookings)
+│         │    │    │    │    └─── BookingController.java             # Steuerung eingehender HTTP-Anfragen für Buchungen
+│         │    │    │    ├─── dto/                                    # Datenübertragungsobjekte für Request/Response im Booking-Modul
+│         │    │    │    │    ├─── BookingResponse.java               # Antwort-DTO für die API – definiert, welche Buchungsdaten als JSON zurückgegeben werden
+│         │    │    │    │    └─── NewBookingRequest.java             # Eingabeobjekt für neue Buchungen (z. B. via JSON)
+│         │    │    │    ├─── mapper/                                 # Transformation zwischen Entities/Modellen und DTOs für Buchungen
+│         │    │    │    │    ├─── BookingMapper.java                 # Interface für die Umwandlung zwischen Entity/Model und BookingResponse
+│         │    │    │    │    └─── BookingMapperImpl.java             # Implementierung des Mappers – enthält konkrete Logik für Entity/Model → DTO
+│         │    │    │    ├─── model/                                  # Interne Datenmodelle des Booking-Moduls
+│         │    │    │    │    ├─── Booking.java                       # Geschäftsmodell (optional, für interne Logik)
+│         │    │    │    │    └─── BookingEntity.java                 # JPA-Entity zur Abbildung von Buchungen in der Datenbank
+│         │    │    │    ├─── repository/                             # Schnittstelle zur Speicherung und Abfrage von Buchungen
+│         │    │    │    │    └─── BookingRepository.java             # Repository-Interface für die Datenzugriffsschicht (JPA)
+│         │    │    │    └─── service/                                # Geschäftslogik für Buchungen (z. B. erstellen, prüfen, stornieren)
+│         │    │    │         ├─── BookingService.java                # Interface zur Definition der Buchungs-Serviceverträge
+│         │    │    │         └─── BookingServiceImpl.java            # Implementierung der Buchungslogik
 │         │    │    │
 │         │    │    └─── Application.java                             # Einstiegspunkt der Spring Boot Anwendung (main-Methode + Spring-Kontext)
 │         │    │

--- a/src/main/java/com/semsoko/webstartbackend/booking/controller/BookingController.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/controller/BookingController.java
@@ -1,4 +1,25 @@
 package com.semsoko.webstartbackend.booking.controller;
 
+import com.semsoko.webstartbackend.booking.dto.NewBookingRequest;
+import com.semsoko.webstartbackend.booking.dto.BookingResponse;
+import com.semsoko.webstartbackend.booking.service.BookingService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/bookings")
 public class BookingController {
+    private final BookingService bookingService;
+
+    public BookingController(BookingService bookingService){
+       this.bookingService = bookingService;
+    }
+
+    @PostMapping
+    public ResponseEntity<BookingResponse> createBooking(@RequestBody NewBookingRequest request){
+        BookingResponse response = bookingService.createBooking(request);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/controller/BookingController.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/controller/BookingController.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.controller;
+
+public class BookingController {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/dto/BookingResponse.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/dto/BookingResponse.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.dto;
+
+public class BookingResponse {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/dto/NewBookingRequest.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/dto/NewBookingRequest.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.dto;
+
+public class NewBookingRequest {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapper.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapper.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.mapper;
+
+public interface BookingMapper {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapperImpl.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapperImpl.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.mapper;
+
+public class BookingMapperImpl {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/model/Booking.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/model/Booking.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.model;
+
+public class Booking {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/model/BookingEntity.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/model/BookingEntity.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.model;
+
+public class BookingEntity {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/repository/BookingRepository.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/repository/BookingRepository.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.repository;
+
+public interface BookingRepository {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/service/BookingService.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/service/BookingService.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.service;
+
+public interface BookingService {
+}

--- a/src/main/java/com/semsoko/webstartbackend/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/service/BookingServiceImpl.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.booking.service;
+
+public class BookingServiceImpl {
+}


### PR DESCRIPTION
### Hintergrund

Dieser PR legt das Grundgerüst für das neue booking-Modul im Java-Backend an.
Ziel ist es, ein eigenes Modul für Buchungsfunktionalität bereitzustellen, das analog zur bestehenden todo-Struktur aufgebaut ist.

---

### Änderungen im Detail

- Projektstruktur für booking/-Modul eingeführt (controller, dto, mapper, model, repository, service)
- Leere Interface- und Klassendateien erstellt (Scaffold)
- BookingController mit initialem POST /api/bookings-Endpunkt implementiert
- README um Booking-Modulstruktur erweitert

---

### Ziel / Zweck des PRs

Das Modulgerüst für Buchungen soll frühzeitig angelegt werden, um in Folge-Branches einzelne Funktionen schrittweise und sauber implementieren zu können.

---

### Hinweise für Reviewer

- Noch keine Fachlogik enthalten – reine Struktur
- BookingService-Interface und Mapper sind Platzhalter ohne Logik