### PR TITLE
Feat/booking post create booking

### DIFF
--- a/src/main/java/com/semsoko/webstartbackend/booking/dto/BookingResponse.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/dto/BookingResponse.java
@@ -1,4 +1,67 @@
 package com.semsoko.webstartbackend.booking.dto;
 
-public class BookingResponse {
+import java.time.LocalDateTime;
+
+public class BookingResponse{
+    private Long id;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private Long userId;
+    private Long resourceId;
+
+    private boolean canceled;
+
+    /**
+     * Getter und Setter
+     */
+
+    public Long getId(){
+        return id;
+    }
+
+    public LocalDateTime getStartTime(){
+        return this.startTime;
+    }
+
+    public LocalDateTime getEndTime(){
+        return this.endTime;
+    }
+
+    public Long getUserId(){
+        return this.userId;
+    }
+
+    public Long getResourceId(){
+        return this.resourceId;
+    }
+
+    public boolean isCanceled(){
+        return this.canceled;
+    }
+
+    public void setId(Long id){
+        this.id = id;
+    }
+
+    public void setStartTime(LocalDateTime startTime){
+        this.startTime = startTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime){
+        this.endTime = endTime;
+    }
+
+    public void setUserId(Long userId){
+        this.userId = userId;
+    }
+
+    public void setResourceId(Long resourceId){
+        this.resourceId = resourceId;
+    }
+
+    public void setCanceled(boolean canceled){
+        this.canceled = canceled;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/dto/NewBookingRequest.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/dto/NewBookingRequest.java
@@ -1,4 +1,50 @@
 package com.semsoko.webstartbackend.booking.dto;
 
+/**
+ * Zeitformat: "2025-08-07T14:00:00"
+ */
+import java.time.LocalDateTime;
+
 public class NewBookingRequest {
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private Long userId;
+    private Long resourceId;
+
+    /**
+     * Getter und Setter
+     */
+
+    public LocalDateTime getSTartTime(){
+        return this.startTime;
+    }
+
+    public LocalDateTime getEndTime(){
+        return endTime;
+    }
+
+    public Long getUserId(){
+        return this.userId;
+    }
+
+    public void setStartTime(LocalDateTime startTime){
+        this.startTime = startTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime){
+        this.endTime = endTime;
+    }
+
+    public void setUserId(Long userId){
+        this.userId = userId;
+    }
+
+    public Long getResourceId(){
+        return this.resourceId;
+    }
+
+    public void setResourceId(Long resourceId){
+        this.resourceId = resourceId;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapper.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapper.java
@@ -1,4 +1,10 @@
 package com.semsoko.webstartbackend.booking.mapper;
 
-public interface BookingMapper {
+import com.semsoko.webstartbackend.booking.dto.NewBookingRequest;
+import com.semsoko.webstartbackend.booking.dto.BookingResponse;
+import com.semsoko.webstartbackend.booking.model.BookingEntity;
+
+public interface BookingMapper{
+    BookingEntity toEntity(NewBookingRequest request);
+    BookingResponse toResponse(BookingEntity entity);
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapperImpl.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/mapper/BookingMapperImpl.java
@@ -1,4 +1,35 @@
 package com.semsoko.webstartbackend.booking.mapper;
 
-public class BookingMapperImpl {
+import com.semsoko.webstartbackend.booking.dto.NewBookingRequest;
+import com.semsoko.webstartbackend.booking.dto.BookingResponse;
+import com.semsoko.webstartbackend.booking.model.BookingEntity;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookingMapperImpl implements BookingMapper{
+    @Override
+    public BookingEntity toEntity(NewBookingRequest request){
+        BookingEntity entity = new BookingEntity();
+        entity.setStartTime(request.getSTartTime());
+        entity.setEndTime(request.getEndTime());
+        entity.setUserId(request.getUserId());
+        entity.setResourceId(request.getResourceId());
+        entity.setCanceled(false);
+
+        return entity;
+    }
+
+    @Override
+    public BookingResponse toResponse(BookingEntity entity){
+        BookingResponse response = new BookingResponse();
+        response.setId(entity.getId());
+        response.setStartTime(entity.getStartTime());
+        response.setEndTime(entity.getEndTime());
+        response.setUserId(entity.getUserId());
+        response.setResourceId(entity.getResourceId());
+        response.setCanceled(entity.isCanceled());
+
+        return response;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/model/Booking.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/model/Booking.java
@@ -1,4 +1,11 @@
 package com.semsoko.webstartbackend.booking.model;
 
+/**
+ * Optionales Geschaeftsmodell fuer Booking. Wird aktuell
+ * nicht genutzt.
+ */
 public class Booking {
+    /**
+     * TODO: Wird bei Bedarf mit Logik gefuellt.
+     */
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/model/BookingEntity.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/model/BookingEntity.java
@@ -1,4 +1,73 @@
 package com.semsoko.webstartbackend.booking.model;
 
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "bookings")
 public class BookingEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private Long userId;
+    private Long resourceId;
+
+    private boolean canceled;
+
+    /**
+     * Getter und Setter
+     */
+
+    public Long getId(){
+        return this.id;
+    }
+
+    public void setId(Long id){
+        this.id = id;
+    }
+
+    public LocalDateTime getStartTime(){
+        return this.startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime){
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime(){
+        return this.endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime){
+        this.endTime = endTime;
+    }
+
+    public Long getUserId(){
+        return userId;
+    }
+
+    public void setUserId(Long userId){
+        this.userId = userId;
+    }
+
+    public Long getResourceId(){
+        return this.resourceId;
+    }
+
+    public void setResourceId(Long resourceId){
+        this.resourceId = resourceId;
+    }
+
+    public boolean isCanceled(){
+        return this.canceled;
+    }
+
+    public void setCanceled(boolean canceled){
+        this.canceled = canceled;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/repository/BookingRepository.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/repository/BookingRepository.java
@@ -1,4 +1,14 @@
 package com.semsoko.webstartbackend.booking.repository;
 
-public interface BookingRepository {
+import com.semsoko.webstartbackend.booking.model.BookingEntity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookingRepository extends JpaRepository<BookingEntity, Long>{
+    /**
+     * Erweiterbar z.B. mit findByUserId(...) etc
+     */
+    
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/repository/BookingRepository.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/repository/BookingRepository.java
@@ -10,5 +10,5 @@ public interface BookingRepository extends JpaRepository<BookingEntity, Long>{
     /**
      * Erweiterbar z.B. mit findByUserId(...) etc
      */
-    
+
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/service/BookingService.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/service/BookingService.java
@@ -1,4 +1,8 @@
 package com.semsoko.webstartbackend.booking.service;
 
+import com.semsoko.webstartbackend.booking.dto.NewBookingRequest;
+import com.semsoko.webstartbackend.booking.dto.BookingResponse;
+
 public interface BookingService {
+    BookingResponse createBooking(NewBookingRequest request);
 }

--- a/src/main/java/com/semsoko/webstartbackend/booking/service/BookingServiceImpl.java
+++ b/src/main/java/com/semsoko/webstartbackend/booking/service/BookingServiceImpl.java
@@ -1,4 +1,31 @@
 package com.semsoko.webstartbackend.booking.service;
 
-public class BookingServiceImpl {
+import com.semsoko.webstartbackend.booking.dto.NewBookingRequest;
+import com.semsoko.webstartbackend.booking.dto.BookingResponse;
+import com.semsoko.webstartbackend.booking.mapper.BookingMapper;
+import com.semsoko.webstartbackend.booking.model.BookingEntity;
+import com.semsoko.webstartbackend.booking.repository.BookingRepository;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookingServiceImpl implements BookingService{
+    private final BookingRepository bookingRepository;
+    private final BookingMapper bookingMapper;
+
+    public BookingServiceImpl(
+            BookingRepository bookingRepository,
+            BookingMapper bookingMapper)
+    {
+        this.bookingRepository = bookingRepository;
+        this.bookingMapper = bookingMapper;
+    }
+
+    @Override
+    public BookingResponse createBooking(NewBookingRequest request){
+        BookingEntity entity = bookingMapper.toEntity(request);
+        BookingEntity saved = bookingRepository.save(entity);
+
+        return bookingMapper.toResponse(saved);
+    }
 }


### PR DESCRIPTION
### Hintergrund

Im vorherigen Branch feat/booking-module-jpa-scaffold wurde das Grundgerüst für das booking-Modul angelegt, inkl. Controller, Service-Interface und Mapper-Interface als Platzhalter. Mit diesem PR wird die fachliche Logik für den bereits vorhandenen POST /api/bookings-Endpunkt vollständig implementiert, sodass Buchungen nun tatsächlich angelegt und in der Datenbank gespeichert werden können.

---

### Änderungen im Detail

- NewBookingRequest-DTO hinzugefügt, um Request-Daten (Startzeit, Endzeit, User, Resource) entgegenzunehmen
- BookingResponse-DTO hinzugefügt, um Buchungsinformationen nach Erstellung zurückzugeben
- BookingEntity mit JPA-Annotationen erstellt, um Buchungen in der Datenbank zu persistieren
- BookingRepository als JpaRepository implementiert
- BookingMapper + BookingMapperImpl implementiert, um zwischen DTO und Entity zu konvertieren
- BookingService um Methode createBooking(...) erweitert
- BookingServiceImpl implementiert, inkl. Persistierung der Buchung über BookingRepository
- BookingController (aus Scaffold) an die implementierte Service-Logik angebunden

---

### Ziel / Zweck des PRs

Der Endpunkt POST /api/bookings soll vollständig funktionsfähig sein und neue Buchungen in der Datenbank anlegen, inklusive Rückgabe aller relevanten Buchungsinformationen im Response.