### PR TITLE
refactor(controller/todo): use ApiResponseFactory for unified success…

### DIFF
--- a/src/main/java/com/semsoko/webstartbackend/todo/controller/TodoController.java
+++ b/src/main/java/com/semsoko/webstartbackend/todo/controller/TodoController.java
@@ -1,84 +1,98 @@
 package com.semsoko.webstartbackend.todo.controller;
 
+import com.semsoko.webstartbackend.shared.api.ApiResponse;
+import com.semsoko.webstartbackend.shared.api.ApiResponseFactory;
 import com.semsoko.webstartbackend.todo.dto.NewTodoRequest;
 import com.semsoko.webstartbackend.todo.dto.TodoResponse;
 import com.semsoko.webstartbackend.todo.service.TodoService;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 /**
  * REST-Controller fuer das Todo-Modul.
  *
- * Basisroute: /api/todos
+ * Basisroute: /api/v1/todos
  *
  * Delegiert Aufrufe an {@link TodoService} - je nach aktiviertem Profil.
+ * Erfolgreiche Antworten werden über {@link ApiResponseFactory} in einheitlichem
+ * JSON-Format zurückgegeben, Fehler werden zentral über den GlobalExceptionHandler verarbeitet.
  */
 @RestController
-@RequestMapping("api/todos")
+@RequestMapping("api/v1/todos")
 public class TodoController {
     private final TodoService todoService;
+    private final ApiResponseFactory apiResponseFactory;
 
     /**
      * Konstruktor-basierte Abhaengigkeitsinjektion.
      * Spring injiziert autoamtisch die passende {@link TodoService}-Implementierung,
      * abhaengig vom aktiven Profil (z.B. "dev" oder "prod").
      *
-     * @param todoService
+     * @param todoService           Service-Implementierung fuer Todo-Operationen
+     * @param apiResponseFactory    Factory fuer einheitliche API-Antworten
      */
-    public TodoController(TodoService todoService){
+    public TodoController(
+            TodoService todoService,
+            ApiResponseFactory apiResponseFactory
+    ){
         this.todoService = todoService;
+        this.apiResponseFactory = apiResponseFactory;
     }
 
     /**
      * Erstellt ein neues Todo auf Basis der Client-Anfrage.
      *
      * @param request Eingabedaten vom Client (JSON)
-     * @return Datenstruktur zur API-Ausgabe (JSON)
+     * @return Erfolgsantwort mit dem erstellten Todo
      */
     @PostMapping
-    public TodoResponse create(@RequestBody NewTodoRequest request){
-        return todoService.createTodo(request);
+    public ResponseEntity<ApiResponse<TodoResponse>> create(
+            @RequestBody NewTodoRequest request
+    ){
+        TodoResponse created = todoService.createTodo(request);
+        return ResponseEntity.ok(apiResponseFactory.success(created));
     }
 
     /**
      * Gibt eine Liste aller gespeicherten Todos zurueck.
      *
-     * @return Liste von {@link TodoResponse}-Objekten
+     * @return Erfolgsantwort mit Liste von Todos
      */
     @GetMapping
-    public List<TodoResponse> findAll(){
-        return todoService.findAll();
+    public ResponseEntity<ApiResponse<List<TodoResponse>>> findAll(){
+        List<TodoResponse> todos = todoService.findAll();
+        return ResponseEntity.ok(apiResponseFactory.success(todos));
     }
 
     /**
      * Loescht ein Todo anhand der ID.
      *
-     * Beispiel: DELETE /api/todos/3
-     *
-     * Gibt 204 No Content zurueck bei Erfolg.
+     * Beispiel: DELETE /api/v1/todos/3
      *
      * @param id ID des zu loeschenden Todos
+     * @return Erfolgsantwort ohne Payload
      */
     @DeleteMapping("{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id){
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id){
         todoService.deleteById(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(apiResponseFactory.success(null));
     }
 
     /**
      * Schaltet den Erledigt-Status (done) eines Todos um.
      *
-     * Beispiel: PATCH /api/todos/3/toggle
+     * Beispiel: PATCH /api/v1/todos/3/toggle
      *
      * @param id ID des zu toggelnden Todos
-     * @return Aktualisiertes Todos als {@link TodoResponse}
+     * @return Erfolgsantwort mit dem aktualisierten Todo
      */
     @PatchMapping("{id}/toggle")
-    public TodoResponse toggle(@PathVariable Long id){
-        return todoService.toggleDoneStatus(id);
+    public ResponseEntity<ApiResponse<TodoResponse>> toggle(@PathVariable Long id){
+        TodoResponse updated = todoService.toggleDoneStatus(id);
+        return ResponseEntity.ok(apiResponseFactory.success(updated));
     }
 }


### PR DESCRIPTION
### Hintergrund

Der bestehende TodoController gab rohe DTOs oder einfache ResponseEntity-Objekte zurück und hatte kein einheitliches JSON-Antwortformat. Um konsistentes API-Verhalten zu gewährleisten und die Fehlerbehandlung zu zentralisieren, soll der Controller die neue ApiResponseFactory nutzen.

---

### Änderungen im Detail

- Controller-Basisroute von /api/todos auf /api/v1/todos geändert (API-Versionierung).
- Alle Endpunkte des TodoController so angepasst, dass sie ResponseEntity<ApiResponse<...>> zurückgeben.
- Erfolgsantworten werden nun über ApiResponseFactory.success(...) erzeugt.
- Entfernen manueller Fehlerbehandlung im Controller – Fehler werden nun über GlobalExceptionHandler verarbeitet.

---

### Ziel / Zweck des PRs

- Einheitliche, versionierte API-Responses im Todo-Modul.
- Zentrale Fehlerbehandlung ohne redundanten Code im Controller.
- Vorbereitung für konsistente API-Nutzung im neuen React-Frontend.

---

### Testhinweise

1. API-Endpunkte für Todos aufrufen:
  - GET /api/v1/todos
  - POST /api/v1/todos
  - PATCH /api/v1/todos/{id}/toggle
  - DELETE /api/v1/todos/{id}

2. Prüfen, ob die Antwortstruktur immer das Schema hat:
{
  "success": true,
  "data": ...,
  "error": null
}

3. Absichtlich fehlerhafte Requests senden (z. B. ungültige ID) → prüfen, ob ein Fehlerobjekt zurückkommt:
{
  "success": false,
  "data": null,
  "error": {
    "code": "...",
    "message": "..."
  }
}


---

### Hinweise für Reviewer

- Dieser PR betrifft nur den TodoController.
- Keine Änderungen an Service- oder Repository-Ebene.
- Funktionalität sollte unverändert bleiben – lediglich Response-Format und Pfade sind angepasst.