### PR TITLE
Feat/shared/jwt utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ WebStart-Backend-Java/
 │         │    │    │    │    ├─── DefaultApiResponseFactory.java     # Standardimplementierung von ApiResponseFactory
 │         │    │    │    │    └─── GlobalExceptionHandler.java        # Zentrales Exception-Handling, liefert standardisierte Fehler-Responses
 │         │    │    │    └─── util/                                   # Hilfsklassen & Werkzeuge für Authentifizierung
-│         │    │    │         ├─── JwtUtil.java                       # Utility-Klasse zum Erzeugen, Validieren und Parsen von JWTs
+│         │    │    │         ├─── JwtUtil.java                       # Interface für JWT-Operationen (Erzeugen, Validieren, Parsen von Tokens)
+│         │    │    │         ├─── JwtUtilImpl.java                   # Standardimplementierung von JwtUtil mit konkreter JWT-Logik (z. B. via jjwt)
 │         │    │    │         └─── PasswordHasher.java                # Utility-Klasse zum sicheren Hashen und Verifizieren von Passwörtern
 │         │    │    ├─── todo/                                        # Modul für Todo-Funktionalität
 │         │    │    │    ├─── controller/                             # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/todos)

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.postgresql:postgresql'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/semsoko/webstartbackend/auth/model/TokenClaims.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/model/TokenClaims.java
@@ -1,4 +1,156 @@
 package com.semsoko.webstartbackend.auth.model;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Repräsentiert die Claims, die in einem JWT enthalten sind.
+ *
+ * Claims sind Informationen über den Benutzer oder das Token selbst,
+ * die in einem JWT (JSON Web Token) gespeichert werden. Sie dienen
+ * zur Authentifizierung (Nachweis der Identität) und Autorisierung
+ * (Zugriffsrechte) eines Benutzers.
+ *
+ * Diese Klasse kapselt u. a.:
+ * Benutzer-ID
+ * Rollen des Benutzers
+ * JTI (eindeutige Token-ID)
+ * Ausstellungszeitpunkt (iat)
+ * Ablaufzeitpunkt (exp)
+ */
+
 public class TokenClaims {
+    /**
+     * Eindeutige ID des Benutzers, auf den sich das Token bezieht.
+     */
+    private String userId;
+
+    /**
+     * Liste der Rollen, die dem Benutzer zugeordnet sind.
+     * Diese werden zur Autorisierungsprüfung verwendet.
+     */
+    private List<String> roles;
+
+    /**
+     * Eindeutige Token-ID (JWT ID, "jti"), um einzelne Tokens
+     * identifizieren und ggf. widerrufen zu können.
+     */
+    private String jti;
+
+    /**
+     * Zeitpunkt, an dem das Token ausgestellt wurde ("issued at").
+     */
+    private Instant iat;
+
+    /**
+     * Zeitpunkt, an dem das Token abläuft ("expiration").
+     */
+    private Instant exp;
+
+    /**
+     * Standardkonstruktor (erforderlich für Frameworks wie Jackson).
+     */
+    public TokenClaims(){
+
+    }
+
+    /**
+     * Konstruktor zum Erstellen eines vollständigen TokenClaims-Objekts.
+     *
+     * @param userId    Benutzer-ID
+     * @param roles     Liste der Rollen
+     * @param jti       Eindeutige Token-ID
+     * @param iat       Ausstellungszeitpunkt
+     * @param exp       Ablaufzeitpunkt
+     */
+    public TokenClaims(
+            String userId,
+            List<String> roles,
+            String jti,
+            Instant iat,
+            Instant exp
+    ){
+        this.userId = userId;
+        this.roles = roles;
+        this.jti = jti;
+        this.iat = iat;
+        this.exp = exp;
+    }
+
+    public String getUserId(){
+        return this.userId;
+    }
+
+    public void setUserId(String userId){
+        this.userId = userId;
+    }
+
+    public List<String> getRoles(){
+        return this.roles;
+    }
+
+    public void setRoles(List<String> roles){
+        this.roles = roles;
+    }
+
+    public String getJti(){
+        return this.jti;
+    }
+
+    public void setJti(String jti){
+        this.jti = jti;
+    }
+
+    public Instant getIat(){
+        return this.iat;
+    }
+
+    public void setIat(Instant iat){
+        this.iat = iat;
+    }
+
+    public Instant getExp(){
+        return this.exp;
+    }
+
+    public void setExp(Instant exp){
+        this.exp = exp;
+    }
+
+    @Override
+    public String toString(){
+        return "TokenClaims{" +
+                "userId='" + userId + '\'' +
+                ", roles=" + roles +
+                ", jti='" + jti + '\'' +
+                ", iat=" + iat +
+                ", exp=" + exp +
+                '}';
+
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(this == o){
+            return true;
+        }
+
+        if(!(o instanceof TokenClaims)){
+            return false;
+        }
+
+        TokenClaims that = (TokenClaims) o;
+
+        return Objects.equals(userId, that.userId) &&
+                Objects.equals(roles, that.roles) &&
+                Objects.equals(jti, that.jti) &&
+                Objects.equals(iat, that.iat) &&
+                Objects.equals(exp, that.exp);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(userId, roles, jti, iat, exp);
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
@@ -1,7 +1,6 @@
 package com.semsoko.webstartbackend.shared.util;
 
 import com.semsoko.webstartbackend.auth.model.TokenClaims;
-
 import io.jsonwebtoken.JwtException;
 
 /**
@@ -18,14 +17,21 @@ import io.jsonwebtoken.JwtException;
 
 public interface JwtUtil {
     /**
-     * Erzeugt ein signiertes JWT basierend auf den übergebenen Claims.
+     *  Erzeugt ein signiertes Access-Token basierend auf den übergebenen Claims.
      *
-     * @params claims
-     * Objekt mit den zu speichernden Tokeninformationen wie Benutzer-ID, Rollen,
-     * Ausstellungs- und Ablaufzeit.
-     * @return  Signierter JWT-String.
+     *  @param claims Objekt mit den zu speichernden Tokeninformationen
+     *                wie Benutzer-ID, Rollen, Ausstellungs- und Ablaufzeit.
+     * @return Signierter JWT-String für den Zugriff (Access Token).
      */
-    String generateToken(TokenClaims claims);
+    String generateAccessToken(TokenClaims claims);
+
+    /**
+     * Erzeugt ein signiertes Refresh-Token basierend auf den übergebenen Claims.
+     *
+     * @param claims Objekt mit den zu speichernden Tokeninformationen.
+     * @return Signierter JWT-String für das Refresh Token.
+     */
+    String generateRefreshToken(TokenClaims claims);
 
     /**
      * Parst einen JWT-String und gibt die enthaltenen Claims als
@@ -36,6 +42,14 @@ public interface JwtUtil {
      * @throws      io.jsonwebtoken.JwtException wenn der Token ungültig oder manipuliert ist.
      */
     TokenClaims parseToken(String token);
+
+    /**
+     * Prueft, ob ein uebergebener JWT-String abgelaufen ist.
+     *
+     * @param token Der zu pruefende JWT-String.
+     * @return {@code true}, wenn das Ablaufdatum ueberschritten wurde, andernfalls {@code false}.
+     */
+    boolean isTokenExpired(String token);
 
     /**
      * Prüft, ob ein übergebener JWT-String gültig ist.

--- a/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.shared.util;
+
+public interface JwtUtil {
+}

--- a/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
@@ -1,4 +1,52 @@
 package com.semsoko.webstartbackend.shared.util;
 
+import com.semsoko.webstartbackend.auth.model.TokenClaims;
+
+import io.jsonwebtoken.JwtException;
+
+/**
+ * Schnittstelle für Hilfsmethoden zur Arbeit mit JSON Web Tokens (JWT).
+ *
+ * Diese Utility-Schnittstelle definiert die Kernoperationen zum
+ * Erzeugen, Validieren und Auslesen von JWTs im Rahmen der
+ * Authentifizierungs- und Autorisierungslogik.
+ *
+ * Durch die Verwendung eines Interfaces kann die Implementierung
+ * (z. B. mit unterschiedlichen Signaturalgorithmen oder Bibliotheken)
+ * leicht ausgetauscht oder für Tests gemockt werden.
+ */
+
 public interface JwtUtil {
+    /**
+     * Erzeugt ein signiertes JWT basierend auf den übergebenen Claims.
+     *
+     * @params claims
+     * Objekt mit den zu speichernden Tokeninformationen wie Benutzer-ID, Rollen,
+     * Ausstellungs- und Ablaufzeit.
+     * @return  Signierter JWT-String.
+     */
+    String generateToken(TokenClaims claims);
+
+    /**
+     * Parst einen JWT-String und gibt die enthaltenen Claims als
+     * {@link TokenClaims}-Objekt zurück.
+     *
+     * @param token Der zu parsende JWT-String.
+     * @return      {@link TokenClaims} mit den aus dem Token gelesenen Werten.
+     * @throws      io.jsonwebtoken.JwtException wenn der Token ungültig oder manipuliert ist.
+     */
+    TokenClaims parseToken(String token);
+
+    /**
+     * Prüft, ob ein übergebener JWT-String gültig ist.
+     *
+     * Ein Token ist gültig, wenn:
+     * die Signatur korrekt ist,
+     * das Ablaufdatum nicht überschritten wurde,
+     * und keine Manipulation erkannt wurde.
+     *
+     * @param token Der zu prüfende JWT-String.
+     * @return {@code true}, wenn der Token gueltig ist, andernfalls {@code false}.
+     */
+    boolean isTokenValid(String token);
 }

--- a/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtil.java
@@ -1,4 +1,0 @@
-package com.semsoko.webstartbackend.shared.util;
-
-public class JwtUtil {
-}

--- a/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtilImpl.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtilImpl.java
@@ -1,4 +1,112 @@
 package com.semsoko.webstartbackend.shared.util;
 
-public class JwtUtilImpl {
+import com.semsoko.webstartbackend.auth.model.TokenClaims;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Standardimplementierung von {@link JwtUtil} unter Verwendung der JJWT-Bibliothek.
+ *
+ * Diese Klasse unterstuetzt:
+ * Erzeugung von Access- und Refresh-Token mit HS256
+ * Validierung und Ablaufpruefung
+ * Parsing von TokenClaims aus JWT-Strings
+ */
+@Component
+public class JwtUtilImpl implements JwtUtil{
+    private final SecretKey secretKey;
+    private final long accessTokenExpirationSeconds;
+    private final long refreshTokenExpirationSeconds;
+
+    public JwtUtilImpl(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds,
+            @Value("${jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
+    ){
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpirationSeconds = accessTokenExpirationSeconds;
+        this.refreshTokenExpirationSeconds = refreshTokenExpirationSeconds;
+    }
+
+    @Override
+    public String generateAccessToken(TokenClaims claims){
+        return buildToken(claims, accessTokenExpirationSeconds);
+    }
+
+    @Override
+    public String generateRefreshToken(TokenClaims claims){
+        return buildToken(claims, refreshTokenExpirationSeconds);
+    }
+
+    private String buildToken(TokenClaims claims, long expirationSeconds){
+        Instant now = Instant.now();
+        Instant exp = now.plusSeconds(expirationSeconds);
+
+        return Jwts.builder()
+                .setId(claims.getJti() != null ? claims.getJti() : UUID.randomUUID().toString())
+                .setSubject(claims.getUserId())
+                .claim("roles", claims.getRoles())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(exp))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Override
+    public TokenClaims parseToken(String token) throws JwtException{
+        Jws<Claims> jwsClaims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+
+        Claims body = jwsClaims.getBody();
+
+        return new TokenClaims(
+                body.getSubject(),
+                body.get("roles", List.class),
+                body.getId(),
+                body.getIssuedAt().toInstant(),
+                body.getExpiration().toInstant()
+        );
+    }
+
+    @Override
+    public boolean isTokenExpired(String token){
+        try{
+            Date expiration = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration();
+            return expiration.before(new Date());
+        }catch(JwtException e){
+            /**
+             * Bei Fehler gilt Token als "abgelaufen/ungueltig"
+             */
+            return true;
+        }
+    }
+
+    @Override
+    public boolean isTokenValid(String token){
+        try{
+            parseToken(token);
+            return !isTokenExpired(token);
+        }catch(JwtException e){
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtilImpl.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/util/JwtUtilImpl.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.shared.util;
+
+public class JwtUtilImpl {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,12 @@
 spring.application.name=webstart
 spring.profiles.active=dev-postgres
+
+# JWT Secret
+jwt.secret=dsasdoifgOILSDJFGOIJDFG2399847298347/.,/.,/.,?><>?<2314OIHsdsf
+
+# Ablaufzeiten in Sekunden
+
+# 15 Minuten
+jwt.access-token-expiration-seconds=900
+# 7 Tage
+jwt.refresh-token-expiration-seconds=604800


### PR DESCRIPTION
### Hintergrund

Dieser PR ergänzt das Projekt um eine zentrale Utility für den Umgang mit JSON Web Tokens (JWT), die in allen Modulen wiederverwendet werden kann. Damit wird die Basis für die Authentifizierung und Autorisierung im Backend gelegt.

---

### Änderungen im Detail

- TokenClaims-Klasse hinzugefügt
  - Enthält User-ID, Rollen, Token-ID (jti), Ausstellungszeitpunkt (iat) und Ablaufzeit (exp)
  - Mit equals, hashCode und toString implementiert

- JwtUtil Interface erstellt
  - Definition von Methoden zum Erzeugen, Validieren, Parsen und Ablaufprüfen von JWTs
  - Separate Methoden für Access- und Refresh-Tokens

- JwtUtilImpl implementiert
  - Erstellung und Validierung von JWTs mit HS256 (JJWT-Bibliothek)
  - Secret-Key und Ablaufzeiten aus application.properties konfigurierbar
  - Unterstützung für Access- und Refresh-Token mit unterschiedlichen Laufzeiten

- application.properties erweitert
  - Konfiguration für jwt.secret, jwt.access-token-expiration-seconds und jwt.refresh-token-expiration-seconds

---

### Ziel / Zweck des PRs

Bereitstellung einer standardisierten JWT-Utility, um:
- Tokens sicher zu generieren und zu validieren
- Ablaufzeiten flexibel zu konfigurieren
- Wiederverwendbarkeit im gesamten Projekt sicherzustellen

---

### Testhinweise

Automatische Unit-Tests werden am Ende der Auth-Implementierung ergänzt.

---

### Hinweise für Reviewer

- Secret-Key in application.properties ist aktuell im Klartext hinterlegt – im späteren Deployment muss dieser über eine .env oder Secret Management geladen werden.
- Ablaufzeiten sind in Sekunden konfigurierbar und können leicht angepasst werden.

