### PR TITLE
Feat/auth/redis token store

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ WebStart-Backend-Java/
 │         │    │    │    └─── service/                                # Geschäftslogik für Authentifizierung & Tokenmanagement
 │         │    │    │         ├─── AuthService.java                   # Interface für Authentifizierungs-Operationen
 │         │    │    │         ├─── AuthServiceImpl.java               # Implementierung der Authentifizierungslogik
+│         │    │    │         ├─── RedisTokenStoreService.java        # Implementierung von TokenStoreService mit Redis-Logik
 │         │    │    │         ├─── TokenService.java                  # Interface für Token-Erzeugung und -Verwaltung
 │         │    │    │         ├─── TokenServiceImpl.java              # Implementierung der Token-Logik (JWT-Erstellung, Validierung)
 │         │    │    │         └─── TokenStoreService.java             # Interface für Zugriff auf Redis (Refresh speichern, Blacklist prüfen, löschen)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ WebStart-Backend-Java/
 │         │    │    │    │    ├─── RefreshTokenRequest.java           # Eingabeobjekt für das Anfordern eines neuen Access-Tokens
 │         │    │    │    │    └─── RefreshTokenResponse.java          # Antwortobjekt mit neuem Access-/Refresh-Token
 │         │    │    │    ├─── model/                                  # Interne Authentifizierungs- und Autorisierungsmodelle
+│         │    │    │    │    ├─── RefreshTokenMetadata.java          # Metadaten zum Refresh Token (z. B. issuedAt, IP, User-Agent)
 │         │    │    │    │    ├─── Role.java                          # Benutzerrolle(n) für Berechtigungsprüfung
 │         │    │    │    │    ├─── TokenClaims.java                   # Datenstruktur der JWT-Claims (z.B. User-ID, Rollen)
 │         │    │    │    │    └─── User.java                          # Benutzer-Entity bzw. -Domainmodell
@@ -25,7 +26,8 @@ WebStart-Backend-Java/
 │         │    │    │         ├─── AuthService.java                   # Interface für Authentifizierungs-Operationen
 │         │    │    │         ├─── AuthServiceImpl.java               # Implementierung der Authentifizierungslogik
 │         │    │    │         ├─── TokenService.java                  # Interface für Token-Erzeugung und -Verwaltung
-│         │    │    │         └─── TokenServiceImpl.java              # Implementierung der Token-Logik (JWT-Erstellung, Validierung)
+│         │    │    │         ├─── TokenServiceImpl.java              # Implementierung der Token-Logik (JWT-Erstellung, Validierung)
+│         │    │    │         └─── TokenStoreService.java             # Interface für Zugriff auf Redis (Refresh speichern, Blacklist prüfen, löschen)
 │         │    │    ├─── booking/                                     # Modul für Buchungsfunktionalität
 │         │    │    │    ├─── controller/                             # REST-Controller mit den HTTP-Endpunkten (z. B. POST /api/bookings)
 │         │    │    │    │    └─── BookingController.java             # Steuerung eingehender HTTP-Anfragen für Buchungen

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ WebStart-Backend-Java/
 │         │    │    │    │    ├─── DefaultApiErrorFactory.java        # Standardimplementierung von ApiErrorFactory
 │         │    │    │    │    ├─── DefaultApiResponseFactory.java     # Standardimplementierung von ApiResponseFactory
 │         │    │    │    │    └─── GlobalExceptionHandler.java        # Zentrales Exception-Handling, liefert standardisierte Fehler-Responses
+│         │    │    │    ├─── config/                                 # Globale Konfigurationsklassen (z. B. Redis, Caching, Mapper)
+│         │    │    │    │    └─── RedisConfig.java                   # RedisTemplate-Bean mit String-basierter Serialisierung für Schlüssel/Werte
 │         │    │    │    └─── util/                                   # Hilfsklassen & Werkzeuge für Authentifizierung
 │         │    │    │         ├─── JwtUtil.java                       # Interface für JWT-Operationen (Erzeugen, Validieren, Parsen von Tokens)
 │         │    │    │         ├─── JwtUtilImpl.java                   # Standardimplementierung von JwtUtil mit konkreter JWT-Logik (z. B. via jjwt)

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.postgresql:postgresql'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/semsoko/webstartbackend/auth/model/RefreshTokenMetadata.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/model/RefreshTokenMetadata.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.auth.model;
+
+public class RefreshTokenMetadata {
+}

--- a/src/main/java/com/semsoko/webstartbackend/auth/model/RefreshTokenMetadata.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/model/RefreshTokenMetadata.java
@@ -1,4 +1,54 @@
 package com.semsoko.webstartbackend.auth.model;
 
+import java.time.Instant;
+
 public class RefreshTokenMetadata {
+    private Instant issuedAt;
+    private String userAgent;
+    private String ipAddress;
+
+    public RefreshTokenMetadata(){}
+
+    public RefreshTokenMetadata(
+            Instant issuedAt,
+            String userAgent,
+            String ipAddress
+    ){
+        this.issuedAt = issuedAt;
+        this.userAgent = userAgent;
+        this.ipAddress = ipAddress;
+    }
+
+    public Instant getIssuedAt(){
+        return this.issuedAt;
+    }
+
+    public void setIssuedAt(Instant issuedAt){
+        this.issuedAt = issuedAt;
+    }
+
+    public String getUserAgent(){
+        return this.userAgent;
+    }
+
+    public void setUserAgent(String userAgent){
+        this.userAgent = userAgent;
+    }
+
+    public String getIpAddress(){
+        return this.ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress){
+        this.ipAddress = ipAddress;
+    }
+
+    @Override
+    public String toString(){
+        return "RefreshTokenMetadata{" +
+                "issuedAt=" + issuedAt +
+                ", userAgent='" + userAgent + '\'' +
+                ", ipAddress='" + ipAddress + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/auth/service/RedisTokenStoreService.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/service/RedisTokenStoreService.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.auth.service;
+
+public class RedisTokenStoreService {
+}

--- a/src/main/java/com/semsoko/webstartbackend/auth/service/RedisTokenStoreService.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/service/RedisTokenStoreService.java
@@ -1,4 +1,108 @@
 package com.semsoko.webstartbackend.auth.service;
 
-public class RedisTokenStoreService {
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.semsoko.webstartbackend.auth.model.RefreshTokenMetadata;
+import com.semsoko.webstartbackend.auth.model.TokenClaims;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import java.util.Set;
+
+@Service
+public class RedisTokenStoreService implements TokenStoreService{
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public RedisTokenStoreService(
+            RedisTemplate<String, String> redisTempalte,
+            ObjectMapper objectMapper
+    ){
+        this.redisTemplate = redisTempalte;
+        this.objectMapper = objectMapper;
+    }
+
+    private String getRefreshTokenKey(String userId, String jti){
+        return String.format("refresh:%s%s", userId, jti);
+    }
+
+    private String getRefreshIndexKey(String userId){
+        return String.format("refresh:index:%s", userId);
+    }
+
+    private String getBlackListKey(String jti){
+        return "blacklist:" + jti;
+    }
+
+    @Override
+    public void storeRefreshToken(
+            TokenClaims claims,
+            RefreshTokenMetadata metadata
+    ){
+        try{
+            String userId = claims.getUserId();
+            String token = claims.getJti();
+            Duration ttl = Duration.between(Instant.now(), claims.getExp());
+
+            String tokenKey = getRefreshTokenKey(userId, token);
+            String metadataJson = objectMapper.writeValueAsString(metadata);
+
+            redisTemplate.opsForValue().set(tokenKey, metadataJson, ttl);
+
+            String indexKey = getRefreshIndexKey(userId);
+            redisTemplate.opsForSet().add(indexKey, tokenKey);
+        }catch(Exception e){
+            throw new RuntimeException("Failed to store refresh token in Redis", e);
+        }
+    }
+
+    @Override
+    public boolean isRefreshTokenValid(
+            String userId,
+            String jti
+    ){
+        String tokenKey = getRefreshTokenKey(userId, jti);
+
+        return Boolean.TRUE.equals(redisTemplate.hasKey(tokenKey));
+    }
+
+    @Override
+    public void deleteRefreshToken(String userId, String jti){
+        String tokenKey = getRefreshTokenKey(userId, jti);
+        String indexKey = getRefreshIndexKey(userId);
+
+        redisTemplate.delete(tokenKey);
+        redisTemplate.opsForSet().remove(indexKey, tokenKey);
+    }
+
+    @Override
+    public void deleteAllRefreshTokensForUser(String userId){
+        String indexKey = getRefreshIndexKey(userId);
+
+        Set<String> tokenKeys = redisTemplate.opsForSet().members(indexKey);
+
+        if(tokenKeys != null && !tokenKeys.isEmpty()){
+            redisTemplate.delete(tokenKeys);
+        }
+
+        redisTemplate.delete(indexKey);
+    }
+
+    @Override
+    public void blacklistAccessToken(String jti, Instant expiration){
+        String key = getBlackListKey(jti);
+        Duration ttl = Duration.between(Instant.now(), expiration);
+
+        redisTemplate.opsForValue().set(key, "1", ttl);
+    }
+
+    @Override
+    public boolean isAccessTokenBlacklisted(String jti){
+        String key = getBlackListKey(jti);
+
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/auth/service/TokenStoreService.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/service/TokenStoreService.java
@@ -1,4 +1,22 @@
 package com.semsoko.webstartbackend.auth.service;
 
+import com.semsoko.webstartbackend.auth.model.RefreshTokenMetadata;
+import com.semsoko.webstartbackend.auth.model.TokenClaims;
+
+import java.time.Instant;
+
 public interface TokenStoreService {
+    /**
+     * === Refresh Token Store ===
+     */
+    void storeRefreshToken(TokenClaims claims, RefreshTokenMetadata metadata);
+    boolean isRefreshTokenValid(String userId, String jti);
+    void deleteRefreshToken(String userId, String jti);
+    void deleteAllRefreshTokensForUser(String userId);
+
+    /**
+     * === Access Token Blacklist ===
+     */
+    void blacklistAccessToken(String jti, Instant expiration);
+    boolean isAccessTokenBlacklisted(String jti);
 }

--- a/src/main/java/com/semsoko/webstartbackend/auth/service/TokenStoreService.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/service/TokenStoreService.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.auth.service;
+
+public interface TokenStoreService {
+}

--- a/src/main/java/com/semsoko/webstartbackend/shared/config/RedisConfig.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/config/RedisConfig.java
@@ -1,4 +1,30 @@
 package com.semsoko.webstartbackend.shared.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
 public class RedisConfig {
+    /**
+     * Konfiguriert eine RedisTemplate-Bean mit String-Schlüsseln und -Werten.
+     * Ideal für Anwendungen, die JSON serialisierte Daten als Strings speichern (z. B. RefreshTokenMetadata).
+     *
+     * @param factory Verbindungs-Factory für Redis (von Spring Boot bereitgestellt)
+     * @return Konfiguriertes RedisTemplate<String, String>
+     */
+    @Bean
+    public RedisTemplate<String, String>redisTemplate(RedisConnectionFactory factory){
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        /**
+         * Wichtig fuer lesbare Speicherung
+         */
+        template.setDefaultSerializer(new StringRedisSerializer());
+
+        return template;
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/shared/config/RedisConfig.java
+++ b/src/main/java/com/semsoko/webstartbackend/shared/config/RedisConfig.java
@@ -1,0 +1,4 @@
+package com.semsoko.webstartbackend.shared.config;
+
+public class RedisConfig {
+}


### PR DESCRIPTION
### Hintergrund

Im Rahmen der Authentifizierungs- und Autorisierungslogik soll eine robuste und zukunftssichere Token-Verwaltung entstehen. Dazu gehört die Speicherung von Refresh Tokens und das Blacklisting von Access Tokens via Redis.

---

### Änderungen im Detail

- Einführung des TokenStoreService-Interfaces
- Implementierung von RedisTokenStoreService zur Verwaltung von Refresh- und Access Tokens in Redis
- Speicherung von Refresh Tokens inkl. Metadaten (RefreshTokenMetadata) mit TTL
- Blacklisting von JWT Access Tokens basierend auf ihrer JTI
- Hinzufügen der Redis-Abhängigkeit (spring-boot-starter-data-redis) zur build.gradle
- Redis-Konfiguration über eigene RedisConfig mit StringRedisSerializer
- Erweiterung von application-dev-postgres.properties um Redis-Konfiguration

---

### Ziel / Zweck des PRs

- Ermöglicht das zentrale Speichern, Prüfen und Löschen von Refresh Tokens in Redis
- Schafft die Grundlage für Logout und "Logout from all devices"
- Ermöglicht das Sperren kompromittierter Access Tokens (Blacklist)
- Vorbereitung für spätere Tests mit Embedded Redis (noch nicht enthalten)

---

### Testhinweise

- Aktuell noch keine Tests enthalten
- Redis muss lokal laufen (z. B. localhost:6379)

---

### Hinweise für Reviewer

- Token TTL wird anhand der JWT-Exp-Claims berechnet (nicht statisch)
- Alle Redis-Keys sind explizit per Prefix strukturiert (refresh:{userId}:{jti}, etc.)
- Die RedisTemplate verwendet String-basierte Serialisierung für bessere Lesbarkeit und Debugging
- Keine Änderungen außerhalb des Auth-Moduls + zentraler Config