### PR TITLE
Feat/auth/security config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/semsoko/webstartbackend/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/security/JwtAuthenticationFilter.java
@@ -1,4 +1,114 @@
 package com.semsoko.webstartbackend.auth.security;
 
-public class JwtAuthenticationFilter {
+import com.semsoko.webstartbackend.auth.model.TokenClaims;
+import com.semsoko.webstartbackend.auth.service.TokenStoreService;
+import com.semsoko.webstartbackend.shared.util.JwtUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import org.springframework.stereotype.Component;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter{
+    private final JwtUtil jwtUtil;
+    private final TokenStoreService tokenStoreService;
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationFilter(
+            JwtUtil jwtUtil,
+            TokenStoreService tokenStoreService,
+            ObjectMapper objectMapper
+    ){
+        this.jwtUtil = jwtUtil;
+        this.tokenStoreService = tokenStoreService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        /**
+         * Kein Authorization Header oder falsches Format -> weiter
+         */
+        if(authHeader == null || !authHeader.startsWith("Bearer ")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        try{
+            /**
+             * 1. JWT Claims parsen
+             */
+            TokenClaims claims = jwtUtil.parseToken(token);
+
+            /**
+             * 2. Blacklist pruefen
+             */
+            if(tokenStoreService.isAccessTokenBlacklisted(claims.getJti())){
+                sendUnauthorized(response, "Access token ist blacklisted");
+                return;
+            }
+
+            /**
+             * 3. Authentication im SecurityContext setzen
+             */
+            List<SimpleGrantedAuthority> authorities = claims.getRoles().stream()
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(claims.getUserId(), null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }catch(Exception e){
+            /**
+             * Fehler bei Parsing oder Validation -> 401
+             */
+            sendUnauthorized(response, "Invalid or expired JWT");
+            return;
+        }
+
+        /**
+         * 4. Weiter in der Filterkette
+         */
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendUnauthorized(HttpServletResponse response, String message) throws IOException{
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        Map<String, Object> errorBody = Map.of(
+                "error", "Unauthorized",
+                "message", message
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorBody);
+    }
 }

--- a/src/main/java/com/semsoko/webstartbackend/auth/security/SecurityConfig.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/security/SecurityConfig.java
@@ -7,19 +7,24 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            JwtAuthenticationFilter jwtAuthenticationFilter
+    ) throws Exception{
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/semsoko/webstartbackend/auth/security/SecurityConfig.java
+++ b/src/main/java/com/semsoko/webstartbackend/auth/security/SecurityConfig.java
@@ -1,4 +1,26 @@
 package com.semsoko.webstartbackend.auth.security;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
 }


### PR DESCRIPTION
### Hintergrund

Dieser PR ergänzt die Security-Konfiguration für das Authentifizierungssystem. Ziel ist es, den Zugriff auf Endpunkte über JWT-basierte Authentifizierung abzusichern und eine Blacklist-Prüfung via Redis einzubinden.

---

### Änderungen im Detail

- SecurityConfig erstellt:
  - Stateless Session Policy
  - Öffentliche Endpunkte /api/v1/auth/**
  - Absicherung aller anderen Endpunkte

- JwtAuthenticationFilter implementiert:
  - Extrahiert und validiert Access Tokens
  - Prüft Signatur, Ablaufzeit und Redis-Blacklist
  - Setzt Authentication in den SecurityContext

- Filter in die Security-Filterchain vor UsernamePasswordAuthenticationFilter eingehängt

---

### Ziel / Zweck des PRs

Absicherung aller nicht-öffentlichen Endpunkte durch JWT-Authentifizierung mit zentralem Blacklist-Check für Access Tokens. Grundlage für die Integration der späteren AuthController-Endpunkte.

---

### Testhinweise

- API-Endpunkte unter /api/v1/auth/** sind ohne Token erreichbar
- Alle anderen Endpunkte erfordern einen gültigen Access Token
- Blacklisted Tokens werden mit 401 Unauthorized abgewiesen

---

### Hinweise für Reviewer

- Tests für Security-Config und Filter werden in einer späteren Test-Phase ergänzt
- Redis muss für die Blacklist-Prüfung laufen